### PR TITLE
Merge last two stages

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,16 +13,12 @@ RUN bash /resources/install_hadoop.sh
 
 # "java" images are deprecated in favor of "openjdk" ones. However,
 # openjdk:8-jre-alpine currently installs u191, which causes datanode SIGSEGV
-FROM java:${java_version}-jre-alpine AS finish-setup
+FROM java:${java_version}-jre-alpine
 ARG hadoop_home
 COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
 COPY entrypoint.sh /
 # hadoop daemons use ps -p; launch_container.sh uses find -ls
-RUN apk add --no-cache bash procps findutils
-RUN echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
-
-FROM scratch
-ARG hadoop_home
-COPY --from=finish-setup / /
+RUN apk add --no-cache bash procps findutils \
+    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
 ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -11,16 +11,13 @@ COPY resources /resources
 ADD http://www-eu.apache.org/dist/hadoop/common/hadoop-${hadoop_version}/hadoop-${hadoop_version}.tar.gz /resources
 RUN bash /resources/install_hadoop.sh
 
-FROM centos:7 AS finish-setup
+FROM centos:7
 ARG hadoop_home
 ARG java_version
 COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
 COPY entrypoint.sh /
-RUN yum -y install java-1.${java_version}.0-openjdk && yum clean all
-RUN echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
-
-FROM scratch
-ARG hadoop_home
-COPY --from=finish-setup / /
+RUN yum -y install java-1.${java_version}.0-openjdk \
+    && yum clean all \
+    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
 ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -11,18 +11,14 @@ COPY resources /resources
 ADD http://www-eu.apache.org/dist/hadoop/common/hadoop-${hadoop_version}/hadoop-${hadoop_version}.tar.gz /resources
 RUN bash /resources/install_hadoop.sh
 
-FROM ubuntu:18.04 AS finish-setup
+FROM ubuntu:18.04
 ARG hadoop_home
 ARG java_version
 COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
 COPY entrypoint.sh /
 RUN apt -y update && apt -y install \
       openjdk-${java_version}-jre \
-    && apt clean && rm -rf /var/lib/apt-lists/*
-RUN echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
-
-FROM scratch
-ARG hadoop_home
-COPY --from=finish-setup / /
+    && apt clean && rm -rf /var/lib/apt-lists/* \
+    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
 ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR merges the last two stages in each Dockerfile. The final stage was gaining us very little (images are now less than 2% larger, although they do have more layers) at the cost of a more complicated build recipe and, more importantly, mysterious `apt` disruptions in the Ubuntu image, e.g.:

```
W: Problem unlinking the file /var/lib/apt/lists/partial/.apt-acquire-privs-test.B8i2nL - IsAccessibleBySandboxUser (13: Permission denied)
```

Or, even worse:

```
E: Failed to stat /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_bionic-updates_main_binary-amd64_Packages.lz4 - pkgAcqTransactionItem::TransactionState-stat (2: No such file or directory)
```

Triggered by `apt-update` in downstream images.