### PR TITLE
Additional image tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: required
 env:
   - OS=alpine HADOOP_VERSION=3.2.0
   - OS=centos HADOOP_VERSION=3.2.0
-  - OS=ubuntu HADOOP_VERSION=3.2.0
+  - OS=ubuntu HADOOP_VERSION=3.2.0 SHORT_TAG=3 LATEST=true
   - OS=ubuntu HADOOP_VERSION=3.1.2
-  - OS=ubuntu HADOOP_VERSION=2.9.2
+  - OS=ubuntu HADOOP_VERSION=2.9.2 SHORT_TAG=2
 
 script:
   - docker build --build-arg hadoop_version=${HADOOP_VERSION} -f Dockerfile.${OS} -t crs4/hadoop:${HADOOP_VERSION}-${OS} .

--- a/push.sh
+++ b/push.sh
@@ -4,3 +4,13 @@ set -euo pipefail
 
 echo "${CI_PASS}" | docker login -u "${CI_USER}" --password-stdin
 docker push crs4/hadoop:${HADOOP_VERSION}-${OS}
+
+if [ -n "${SHORT_TAG:-}" ]; then
+    docker tag crs4/hadoop:${HADOOP_VERSION}-${OS} crs4/hadoop:${SHORT_TAG}
+    docker push crs4/hadoop:${SHORT_TAG}
+fi
+
+if [ -n "${LATEST:-}" ]; then
+    docker tag crs4/hadoop:${HADOOP_VERSION}-${OS} crs4/hadoop:latest
+    docker push crs4/hadoop:latest
+fi


### PR DESCRIPTION
With crs4/ansible-hadoop#10, old images are not pushed to Docker Hub anymore. This PR reinstates the `2`, `3` and `latest` tags, making them point to images from the new set.