### PR TITLE
Set LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -12,6 +12,7 @@ COPY resources /resources
 ADD http://www-eu.apache.org/dist/hadoop/common/hadoop-${hadoop_version}/hadoop-${hadoop_version}.tar.gz /resources
 RUN bash /resources/install_hadoop.sh
 
+# Java System.loadLibrary ignores ld.so.conf, so we also set LD_LIBRARY_PATH
 FROM ubuntu:18.04
 ARG hadoop_home
 ARG java_version
@@ -20,8 +21,10 @@ COPY entrypoint.sh /
 RUN apt -y update && apt -y install \
       openjdk-${java_version}-jre \
     && apt clean && rm -rf /var/lib/apt-lists/* \
-    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh \
+    && echo "export LD_LIBRARY_PATH=\"${hadoop_home}/lib/native:\${LD_LIBRARY_PATH}\"" >>/etc/profile.d/hadoop.sh \
+    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >>/etc/profile.d/hadoop.sh \
     && echo "${hadoop_home}/lib/native" > /etc/ld.so.conf.d/hadoop.conf \
     && ldconfig
+ENV LD_LIBRARY_PATH="${hadoop_home}/lib/native:${LD_LIBRARY_PATH}"
 ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
While `ld.so.conf` should be enough for other native applications, Java's `System.loadLibrary` ignores it, so we also set `LD_LIBRARY_PATH`. This allows Hadoop's `NativeCodeLoader` to find and load `libhadoop`.