### PR TITLE
Optimize images

### DIFF
--- a/base/Dockerfile.ubuntu
+++ b/base/Dockerfile.ubuntu
@@ -18,9 +18,9 @@ ARG hadoop_home
 ARG java_version
 COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
 COPY entrypoint.sh /
-RUN apt -y update && apt -y install \
-      openjdk-${java_version}-jre \
-    && apt clean && rm -rf /var/lib/apt-lists/* \
+RUN apt-get -y update && apt-get -y install --no-install-recommends \
+      openjdk-${java_version}-jre-headless \
+    && apt-get clean && rm -rf /var/lib/apt-lists/* /tmp/* /var/tmp/* \
     && echo "export LD_LIBRARY_PATH=\"${hadoop_home}/lib/native:\${LD_LIBRARY_PATH}\"" >>/etc/profile.d/hadoop.sh \
     && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >>/etc/profile.d/hadoop.sh \
     && echo "${hadoop_home}/lib/native" > /etc/ld.so.conf.d/hadoop.conf \

--- a/base/resources/install_hadoop.sh
+++ b/base/resources/install_hadoop.sh
@@ -20,3 +20,5 @@ if [ -n "${native_libs_dir:-}" ]; then
     rm -rf "${hadoop_home}"/lib/native/*
     mv "${native_libs_dir}"/* "${hadoop_home}"/lib/native/
 fi
+
+rm -rf "${hadoop_home}"/share/doc


### PR DESCRIPTION
Recent Hadoop binary distributions are more than 50% docs (e.g., 496 / 880 MB for 3.2.0). This PR changes the base image to:
 - remove the Hadoop docs after installation
 - minimize the Java installation in Ubuntu

This brings the uncompressed size for `crs4/hadoop-base:3.2.0-ubuntu` to 780 MB, down from 1.43 GB.