### PR TITLE
Secure DataNode image

### DIFF
--- a/Dockerfile.secdn
+++ b/Dockerfile.secdn
@@ -1,0 +1,11 @@
+ARG hadoop_version=3.2.0
+
+FROM crs4/datanode:${hadoop_version}-ubuntu
+RUN apt-get -y update && apt-get -y install --no-install-recommends \
+      jsvc \
+      libcap2 \
+    && apt-get clean && rm -rf /var/lib/apt-lists/* /tmp/* /var/tmp/* \
+    && echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >>/etc/profile.d/jsvc.sh \
+    && echo "export JSVC_HOME=/usr/bin" >>/etc/profile.d/hadoop.sh
+ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+ENV JSVC_HOME="/usr/bin"

--- a/build.sh
+++ b/build.sh
@@ -24,3 +24,10 @@ for cmd in "${cmd_list[@]}"; do
       --build-arg os=${OS} \
       -t crs4/${cmd}:${HADOOP_VERSION}-${OS} .
 done
+
+if [ "${OS}" == "ubuntu" ]; then
+    docker build \
+      -f Dockerfile.secdn \
+      --build-arg hadoop_version=${HADOOP_VERSION} \
+      -t crs4/securedatanode:${HADOOP_VERSION}-${OS} .
+fi

--- a/push.sh
+++ b/push.sh
@@ -11,6 +11,7 @@ cmd_list=(
     nodemanager
     resourcemanager
 )
+[ "${OS}" == "ubuntu" ] && cmd_list+=( securedatanode )
 
 echo "${CI_PASS}" | docker login -u "${CI_USER}" --password-stdin
 


### PR DESCRIPTION
Adds a new `securedatanode` image with additional dependencies, enabling Hadoop to use privileged ports for the DataNode.

See http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SecureMode.html