### PR TITLE
Add command to get cluster ID from datanode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 script:
   - bash build.sh
   - docker run --rm --name hadoop -d crs4/hadoop:${HADOOP_VERSION}-${OS}
-  - "docker exec hadoop bash -c 'until hdfs dfsadmin -safemode wait 2>/dev/null; do sleep 0.1; done'"
+  - "docker exec hadoop bash -c 'until datanode_cid; do sleep 0.1; done'"
   - docker cp test/check.sh hadoop:/
   - docker exec hadoop bash /check.sh
   - docker stop hadoop

--- a/Dockerfile.secdn
+++ b/Dockerfile.secdn
@@ -7,5 +7,4 @@ RUN apt-get -y update && apt-get -y install --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt-lists/* /tmp/* /var/tmp/* \
     && echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >>/etc/profile.d/jsvc.sh \
     && echo "export JSVC_HOME=/usr/bin" >>/etc/profile.d/hadoop.sh
-ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 ENV JSVC_HOME="/usr/bin"

--- a/base/Dockerfile.alpine
+++ b/base/Dockerfile.alpine
@@ -2,23 +2,20 @@ ARG hadoop_home=/opt/hadoop
 ARG hadoop_version=3.2.0
 ARG java_version=8
 
-FROM alpine:3.9 AS install-hadoop
+# "java" images are deprecated in favor of "openjdk" ones. Unfortunately, with
+# the recent versions of IcedTea found in openjdk:8-jre-alpine, the datanode
+# daemon crashes with a SIGSEGV. Seen with u191 and u201.
+FROM java:${java_version}-jre-alpine
 ARG hadoop_home
 ARG hadoop_version
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
-COPY resources /resources
-ADD http://www-eu.apache.org/dist/hadoop/common/hadoop-${hadoop_version}/hadoop-${hadoop_version}.tar.gz /resources
-RUN apk add --no-cache bash
-RUN bash /resources/install_hadoop.sh
-
-# "java" images are deprecated in favor of "openjdk" ones. However,
-# openjdk:8-jre-alpine currently installs u191, which causes datanode SIGSEGV
-FROM java:${java_version}-jre-alpine
-ARG hadoop_home
-COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
-COPY entrypoint.sh /
-# hadoop daemons use ps -p; launch_container.sh uses find -ls
-RUN apk add --no-cache bash procps findutils \
-    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
 ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
+COPY entrypoint.sh /
+COPY resources /resources
+# hadoop daemons use ps -p; launch_container.sh uses find -ls;
+# install_hadoop.sh uses tar --strip
+RUN apk add --no-cache bash findutils procps tar \
+    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh \
+    && bash /resources/install_hadoop.sh \
+    && rm -rf /resources
 ENTRYPOINT ["/entrypoint.sh"]

--- a/base/Dockerfile.centos
+++ b/base/Dockerfile.centos
@@ -2,22 +2,17 @@ ARG hadoop_home=/opt/hadoop
 ARG hadoop_version=3.2.0
 ARG java_version=8
 
-FROM centos:7 AS install-hadoop
+FROM centos:7
 ARG hadoop_home
 ARG hadoop_version
 ARG java_version
-ENV JAVA_HOME=/usr/lib/jvm/jre-1.${java_version}.0-openjdk
 COPY resources /resources
-ADD http://www-eu.apache.org/dist/hadoop/common/hadoop-${hadoop_version}/hadoop-${hadoop_version}.tar.gz /resources
-RUN bash /resources/install_hadoop.sh
-
-FROM centos:7
-ARG hadoop_home
-ARG java_version
-COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
 COPY entrypoint.sh /
-RUN yum -y install java-1.${java_version}.0-openjdk \
-    && yum clean all \
-    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh
+ENV JAVA_HOME=/usr/lib/jvm/jre-1.${java_version}.0-openjdk
 ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
+RUN yum -y install java-1.${java_version}.0-openjdk wget \
+    && yum clean all \
+    && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >/etc/profile.d/hadoop.sh \
+    && bash /resources/install_hadoop.sh \
+    && rm -rf /resources
 ENTRYPOINT ["/entrypoint.sh"]

--- a/base/Dockerfile.ubuntu
+++ b/base/Dockerfile.ubuntu
@@ -2,29 +2,24 @@ ARG hadoop_home=/opt/hadoop
 ARG hadoop_version=3.2.0
 ARG java_version=8
 
-FROM crs4/hadoop-nativelibs:${hadoop_version}-ubuntu AS install-hadoop
+# Java System.loadLibrary ignores ld.so.conf, so we also set LD_LIBRARY_PATH
+FROM crs4/hadoop-nativelibs:${hadoop_version}-ubuntu
 ARG hadoop_home
 ARG hadoop_version
 ARG java_version
 ENV JAVA_HOME=/usr/lib/jvm/java-${java_version}-openjdk-amd64
-ENV native_libs_dir=/hadoop_native
-COPY resources /resources
-ADD http://www-eu.apache.org/dist/hadoop/common/hadoop-${hadoop_version}/hadoop-${hadoop_version}.tar.gz /resources
-RUN bash /resources/install_hadoop.sh
-
-# Java System.loadLibrary ignores ld.so.conf, so we also set LD_LIBRARY_PATH
-FROM ubuntu:18.04
-ARG hadoop_home
-ARG java_version
-COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
+ENV LD_LIBRARY_PATH="${hadoop_home}/lib/native:${LD_LIBRARY_PATH}"
+ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
 COPY entrypoint.sh /
+COPY resources /resources
 RUN apt-get -y update && apt-get -y install --no-install-recommends \
       openjdk-${java_version}-jre-headless \
+      wget \
     && apt-get clean && rm -rf /var/lib/apt-lists/* /tmp/* /var/tmp/* \
+    && native_libs_dir=/hadoop_native bash /resources/install_hadoop.sh \
     && echo "export LD_LIBRARY_PATH=\"${hadoop_home}/lib/native:\${LD_LIBRARY_PATH}\"" >>/etc/profile.d/hadoop.sh \
     && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >>/etc/profile.d/hadoop.sh \
     && echo "${hadoop_home}/lib/native" > /etc/ld.so.conf.d/hadoop.conf \
-    && ldconfig
-ENV LD_LIBRARY_PATH="${hadoop_home}/lib/native:${LD_LIBRARY_PATH}"
-ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
+    && ldconfig \
+    && rm -rf /resources
 ENTRYPOINT ["/entrypoint.sh"]

--- a/base/Dockerfile.ubuntu
+++ b/base/Dockerfile.ubuntu
@@ -2,24 +2,29 @@ ARG hadoop_home=/opt/hadoop
 ARG hadoop_version=3.2.0
 ARG java_version=8
 
-# Java System.loadLibrary ignores ld.so.conf, so we also set LD_LIBRARY_PATH
-FROM crs4/hadoop-nativelibs:${hadoop_version}-ubuntu
+FROM crs4/hadoop-nativelibs:${hadoop_version}-ubuntu AS install-hadoop
 ARG hadoop_home
 ARG hadoop_version
 ARG java_version
-ENV JAVA_HOME=/usr/lib/jvm/java-${java_version}-openjdk-amd64
-ENV LD_LIBRARY_PATH="${hadoop_home}/lib/native:${LD_LIBRARY_PATH}"
-ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
-COPY entrypoint.sh /
 COPY resources /resources
+RUN apt-get -y update && apt-get -y install wget \
+    && native_libs_dir=/hadoop_native JAVA_HOME=/usr/lib/jvm/java-${java_version}-openjdk-amd64 bash /resources/install_hadoop.sh
+
+# Java System.loadLibrary ignores ld.so.conf, so we also set LD_LIBRARY_PATH
+FROM ubuntu:18.04
+ARG hadoop_home
+ARG java_version
+COPY --from=install-hadoop "${hadoop_home}" "${hadoop_home}"
+COPY entrypoint.sh /
 RUN apt-get -y update && apt-get -y install --no-install-recommends \
       openjdk-${java_version}-jre-headless \
       wget \
     && apt-get clean && rm -rf /var/lib/apt-lists/* /tmp/* /var/tmp/* \
-    && native_libs_dir=/hadoop_native bash /resources/install_hadoop.sh \
     && echo "export LD_LIBRARY_PATH=\"${hadoop_home}/lib/native:\${LD_LIBRARY_PATH}\"" >>/etc/profile.d/hadoop.sh \
     && echo "export PATH=\"${hadoop_home}/bin:${hadoop_home}/sbin:\${PATH}\"" >>/etc/profile.d/hadoop.sh \
     && echo "${hadoop_home}/lib/native" > /etc/ld.so.conf.d/hadoop.conf \
-    && ldconfig \
-    && rm -rf /resources
+    && ldconfig
+ENV JAVA_HOME=/usr/lib/jvm/java-${java_version}-openjdk-amd64
+ENV LD_LIBRARY_PATH="${hadoop_home}/lib/native:${LD_LIBRARY_PATH}"
+ENV PATH="${hadoop_home}/bin:${hadoop_home}/sbin:${PATH}"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/base/resources/datanode_cid
+++ b/base/resources/datanode_cid
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Get the HDFS cluster ID from the DataNode HTTP server. If the DataNode is
+# not connected to a NameNode, output will be "null" and exit value != 0.
+
+set -euo pipefail
+
+addr=$(hdfs getconf -confKey dfs.datanode.http.address)
+url="${addr}/jmx?qry=Hadoop:service=DataNode,name=DataNodeInfo"
+cid=$(wget -q -O - ${url} | grep ClusterId | sed -E 's/^ *"ClusterId" *: *(.*),/\1/')
+echo ${cid}
+test "${cid}" != "null"

--- a/base/resources/install_hadoop.sh
+++ b/base/resources/install_hadoop.sh
@@ -18,6 +18,8 @@ cp -f "${from_conf}"/* "${to_conf}"/
 for name in hadoop mapred yarn; do
     sed -i "1iexport JAVA_HOME=${JAVA_HOME}" "${to_conf}/${name}-env.sh"
 done
+cp -f "${this_dir}"/datanode_cid "${hadoop_home}"/bin/
+chmod +x "${hadoop_home}"/bin/datanode_cid
 
 if [ -n "${native_libs_dir:-}" ]; then
     echo "copying native libs from ${native_libs_dir}"

--- a/base/resources/install_hadoop.sh
+++ b/base/resources/install_hadoop.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 
 this="${BASH_SOURCE-$0}"
 this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
-tar="${this_dir}/hadoop-${hadoop_version}.tar.gz"
+repo="http://www-eu.apache.org/dist/hadoop/common"
+tar="hadoop-${hadoop_version}.tar.gz"
 
 mkdir -p "${hadoop_home}"
-tar xf "${tar}" --strip 1 -C "${hadoop_home}"
+echo "getting ${repo}/hadoop-${hadoop_version}/${tar}"
+wget -q -O - "${repo}/hadoop-${hadoop_version}/${tar}" | \
+    tar xz --strip 1 -C "${hadoop_home}"
 major_version=${hadoop_version%%.*}
 from_conf="${this_dir}/conf/hadoop${major_version}"
 to_conf="${hadoop_home}/etc/hadoop"
@@ -17,8 +20,10 @@ for name in hadoop mapred yarn; do
 done
 
 if [ -n "${native_libs_dir:-}" ]; then
+    echo "copying native libs from ${native_libs_dir}"
     rm -rf "${hadoop_home}"/lib/native/*
     mv "${native_libs_dir}"/* "${hadoop_home}"/lib/native/
+    rm -rf "${native_libs_dir}"
 fi
 
 rm -rf "${hadoop_home}"/share/doc


### PR DESCRIPTION
Adds a `datanode_cid` command that returns the cluster ID as seen by the DataNode:

```
$ docker run --rm --name hadoop -d crs4/hadoop
f084bffbff3929234b974e297f431ec5347a2ff99b829eed4940184e5ec2aef6
$ docker exec hadoop datanode_cid
"CID-473ba4d0-b91f-40a2-9b05-636a4f9d8719"
```

Hadoop exposes this information -- along with other metrics -- via JMX. Until the DataNode successfully connects to a NameNode, the cluster ID is reported as `null`: in this case, the program exits with a non-zero value. This allows the command to be used as a health check, especially useful to work around things like https://jira.apache.org/jira/browse/HADOOP-15129 (see tdm-project/kubehdfs#4 for possible consequences). Indeed, the new command has been put to work immediately in the [Travis build](https://github.com/crs4/hadoop-docker/pull/15/commits/521bfb0ad555f34a2c3f0e2a9c6741089674257c#diff-354f30a63fb0907d4ad57269548329e3R15).

### Implementation notes

The program uses the JMX interface exposed by the DataNode via HTTP. An alternative is `hdfs jmxget`, but that needs to be [explicitly set up](https://www.datadoghq.com/blog/collecting-hadoop-metrics/#namenode-and-datanode-metrics-via-jmx) and thus might easily break if users override the configuration. This means that images now need something that can read via HTTP. I chose `wget` over `curl` since it's much smaller.

### Consequences on images

With this PR image size stays the same (if there is a difference, it's less than 1MB). Except for the Ubuntu version, where we need to avoid carrying over the substantial layer from `crs4/hadoop-nativelibs`, *not* adding `wget` was pretty much the only reason left for keeping stages around (use `ADD` to avoid installing `wget` and then use stages to avoid the big layer from `ADD`), so I was able to simplify the build. In addition, `ADD` always re-downloads the file to check that the remote version hasn't changed, which can be annoying during the development cycle.